### PR TITLE
Fixing all eslint errors

### DIFF
--- a/api/databases/functions.js
+++ b/api/databases/functions.js
@@ -170,7 +170,9 @@ function database_row_change(database, data_index, key, new_value) {
  * @returns {number[]} an array of the matching row numbers
  */
 function lookup_key_value(database, key, value) {
-	//what happens, when multiple modules acess the same database at the same time?!?!?
+	//what happens, when multiple modules access the same database at the same time?!?!?
+	//-> it's undefined behaviour. Each module should only keep track of it's own database.
+	// but just for clearance: Is it even possible to access this at the same time? JS works on one thread only...
 	prepare_request(database);
 	return databases[database].lookup_key_value(key, value);
 }
@@ -227,7 +229,7 @@ function load_database(database) {
 	for (let i = 1; i <= rows.length - keys.length; i += keys.length) {
 		let cache = [];
 		for (let i_k = 0; i_k < keys.length; i_k++) {
-			let row_index = i + i_k;
+			const row_index = i + i_k;
 			cache.push(JSON.parse(rows[row_index]));
 		}
 		data.push(cache);

--- a/api/utility/embeds/functions.js
+++ b/api/utility/embeds/functions.js
@@ -1,5 +1,5 @@
 const Discord = require("discord.js");
-
+const LOGGER = require.main.require("./log.js")("embeds");
 /**
  * Creates an embed with title and description.
  *
@@ -34,7 +34,7 @@ async function emb(title, description, channel) {
 	try {
 		await channel.send(create_embed(title, description));
 	} catch (error) {
-		bot.LOGGER.info(`Error: ${error}`);
+		LOGGER.error(`Error: ${error}`);
 	}
 }
 

--- a/api/utility/embeds/functions.js
+++ b/api/utility/embeds/functions.js
@@ -34,7 +34,7 @@ async function emb(title, description, channel) {
 	try {
 		await channel.send(create_embed(title, description));
 	} catch (error) {
-		LOGGER.error(`Error: ${error}`);
+		LOGGER.error(error.stack);
 	}
 }
 


### PR DESCRIPTION
Fixing all warnings and errors found by eslint.

Wontfix: Unfiltered for..in loop
Checks for unfiltered for-in loops. The use of this construct results in processing inherited or unexpected properties. You need to filter own properties with hasOwnProperty() method.

Reason: Popular frameworks like jQuery don't do it either and unless someone overwrites the iterator of an array there is no need for code cluttering by checking for hasOwnProperty in EVERY for..in loop. 